### PR TITLE
Fix export task when sourceFile is not defined

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
             poi          : '3.17',
             jcifs        : '1.3.17',
             mockitoKotlin: "1.6.0",
-            assertJ      : "3.11.1",
+            assertJ      : "3.15.0",
     ]
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = 'com.github.gradle'
-version = '1.5'
+version = '1.5.1'
 
 repositories {
     jcenter()

--- a/src/main/kotlin/com/github/gradle/android/i18n/AndroidI18nPluginExtension.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/AndroidI18nPluginExtension.kt
@@ -86,6 +86,13 @@ open class AndroidI18nPluginExtension(
      * The file name will be the same as the configured source file.
      */
     fun exportI18nResources() {
+
+        // Remove previous output files
+        project.buildDir.listFiles { file ->
+            file.name.matches("^$BASE_OUTPUT_PATH_PREFIX.*$BASE_OUTPUT_PATH_SUFFIX$".toRegex())
+        }?.forEach { it.delete() }
+
+        // Export to output file
         val formatter = DateTimeFormatter.ofPattern(BASE_OUTPUT_PATH_TIMESTAMP_PATTERN)
         val timestamp = formatter.format(LocalDateTime.now())
         val basePath = "$BASE_OUTPUT_PATH_PREFIX$timestamp$BASE_OUTPUT_PATH_SUFFIX"

--- a/src/main/kotlin/com/github/gradle/android/i18n/AndroidI18nPluginExtension.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/AndroidI18nPluginExtension.kt
@@ -8,7 +8,8 @@ import org.gradle.api.Project
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.InputStream
-import java.nio.file.Paths
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 /**
  * [AndroidI18nPlugin] extension.
@@ -85,7 +86,9 @@ open class AndroidI18nPluginExtension(
      * The file name will be the same as the configured source file.
      */
     fun exportI18nResources() {
-        val basePath = Paths.get(sourceFile).fileName.toString()
+        val formatter = DateTimeFormatter.ofPattern(BASE_OUTPUT_PATH_TIMESTAMP_PATTERN)
+        val timestamp = formatter.format(LocalDateTime.now())
+        val basePath = "$BASE_OUTPUT_PATH_PREFIX$timestamp$BASE_OUTPUT_PATH_SUFFIX"
         val outputFile = File(project.buildDir, basePath)
         outputFile.outputStream().use { outputStream ->
             xlsExporter.export(outputStream, defaultLocale)
@@ -125,5 +128,11 @@ open class AndroidI18nPluginExtension(
                 .forEach {
                     jcifs.Config.setProperty(it.key.substringAfter('.'), it.value.toString().trim())
                 }
+    }
+
+    companion object {
+        private const val BASE_OUTPUT_PATH_PREFIX = "i18n_"
+        private const val BASE_OUTPUT_PATH_TIMESTAMP_PATTERN = "yyyy-MM-dd_HH-mm-ss"
+        private const val BASE_OUTPUT_PATH_SUFFIX = ".xlsx"
     }
 }

--- a/src/test/kotlin/com/github/gradle/android/i18n/import/AndroidI18nPluginExtensionTest.kt
+++ b/src/test/kotlin/com/github/gradle/android/i18n/import/AndroidI18nPluginExtensionTest.kt
@@ -5,12 +5,10 @@ import com.github.gradle.android.i18n.export.XlsExporter
 import com.nhaarman.mockito_kotlin.*
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.api.Project
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import testutil.AbstractUnitTest
-import java.io.File
 import java.io.FileInputStream
 
 /**
@@ -87,15 +85,9 @@ class AndroidI18nPluginExtensionTest : AbstractUnitTest() {
 
         // Then
         then(exporter).should().export(any(), eq("en"))
-        assertContains(buildDir, "i18n_", ".xlsx")
-    }
-
-    @Suppress("SameParameterValue")
-    private fun assertContains(buildDir: File?, prefix: String, suffix: String) {
-        val filesMatchingPattern = buildDir?.listFiles { pathname ->
-            val name = pathname.name
-            name.startsWith(prefix) && name.endsWith(suffix)
-        } ?: arrayOf()
-        assertTrue(filesMatchingPattern.isNotEmpty())
+        assertThat(buildDir).isDirectoryContaining { file ->
+            val name = file.name
+            name.startsWith("i18n_") && name.endsWith(".xlsx")
+        }
     }
 }

--- a/src/test/kotlin/com/github/gradle/android/i18n/import/AndroidI18nPluginExtensionTest.kt
+++ b/src/test/kotlin/com/github/gradle/android/i18n/import/AndroidI18nPluginExtensionTest.kt
@@ -10,8 +10,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import testutil.AbstractUnitTest
+import java.io.File
 import java.io.FileInputStream
-import java.nio.file.Paths
 
 /**
  * Plugin extension tests regarding import task methods.
@@ -78,7 +78,6 @@ class AndroidI18nPluginExtensionTest : AbstractUnitTest() {
         val importer: XlsImporter = mock()
         val exporter: XlsExporter = mock()
         val extension = AndroidI18nPluginExtension(project, importer, exporter)
-        extension.sourceFile = "/path/to/my-i18n-file.xlsx"
         extension.defaultLocale = "en"
         val buildDir = temporaryFolder.newFolder()
         given(project.buildDir).willReturn(buildDir)
@@ -88,6 +87,15 @@ class AndroidI18nPluginExtensionTest : AbstractUnitTest() {
 
         // Then
         then(exporter).should().export(any(), eq("en"))
-        assertTrue(Paths.get(buildDir.path, "my-i18n-file.xlsx").toFile().exists())
+        assertContains(buildDir, "i18n_", ".xlsx")
+    }
+
+    @Suppress("SameParameterValue")
+    private fun assertContains(buildDir: File?, prefix: String, suffix: String) {
+        val filesMatchingPattern = buildDir?.listFiles { pathname ->
+            val name = pathname.name
+            name.startsWith(prefix) && name.endsWith(suffix)
+        } ?: arrayOf()
+        assertTrue(filesMatchingPattern.isNotEmpty())
     }
 }


### PR DESCRIPTION
This PR brings fixes an error of `androidI18nExport` when the `sourceFile` property is not defined.

The plugin did use the base path that was defined in the `sourceFile` property. When executing `androidI18nExport` and the property wasn't defined, there was an error.

This is fixed by generating an output path using a timestamp instead of `sourceFile`, eg. `i18n_2020-04-15_09:09:32.xlsx`.