### PR TITLE
Deduplication task

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ For example if the project has 2 modules:
 ```
 project
 \_app
-| \_key1: value1-overriden
+| \_key1: value1-app
 | \_key3: value3
 \_feature1
     \_key1: value1-feature1
@@ -249,11 +249,11 @@ project
 \_app
 | \_key3: value3
 \_feature1
-    \_key1: value1-overriden
+    \_key1: value1-app
     \_key2: value2
 ```
 
-The key `key1` was in both `app` and `feature1` and its value in `app` was `value1-overriden` ⇒ it gets moved into `feature1`, retaining the value it had in `app`.
+The key `key1` was in both `app` and `feature1` and its value in `app` was `value1-app` ⇒ it gets moved into `feature1`, retaining the value it had in `app`.
 
 But `key3` was only in `app` so it stays in `app`.
 

--- a/README.md
+++ b/README.md
@@ -23,39 +23,7 @@ The plugin provides the following gradle tasks:
     [...]
     ```
 
-- **`androidI18nDeduplicate`**: remove duplicate keys between a given source module and the other modules in the Gradle project. NB: This task operates on the `*strings.xml` files of the project.
-
-    For example if the project has 2 modules:
-    ```
-    project
-    \_app
-    | \_key1: value1-overriden
-    | \_key3: value3
-    \_feature1
-      \_key1: value1-feature1
-      \_key2: value2
-    ```
-    
-    Here is how you call the task:
-
-    ```bash
-    ./gradlew androidI18nDeduplicate -PandroidI18n.deduplicateFrom=app
-    ```
-
-    The task transforms the project to:
-
-    ```
-    project
-    \_app
-    | \_key3: value3
-    \_feature1
-      \_key1: value1-overriden
-      \_key2: value2
-    ```
-
-    The key `key1` was in both `app` and `feature1` and its value in `app` was `value1-overriden` ⇒ it gets moved into `feature1`, retaining the value it had in `app`.
-
-    But `key3` was only in `app` so it stays in `app`.
+- **`androidI18nDeduplicate`**: remove duplicate keys between a given source module and the other modules in the Gradle project.
 
 # Installation
 
@@ -254,6 +222,40 @@ project-multi
 
 </tr>
 </table>
+
+The **deduplication task** will remove duplicate keys between a given source module and the other modules in the Gradle project. NB: This task operates on the `*strings.xml` files of the project.
+
+For example if the project has 2 modules:
+```
+project
+\_app
+| \_key1: value1-overriden
+| \_key3: value3
+\_feature1
+    \_key1: value1-feature1
+    \_key2: value2
+```
+
+Here is how you call the task:
+
+```bash
+./gradlew androidI18nDeduplicate -PandroidI18n.deduplicateFrom=app
+```
+
+The task transforms the project to:
+
+```
+project
+\_app
+| \_key3: value3
+\_feature1
+    \_key1: value1-overriden
+    \_key2: value2
+```
+
+The key `key1` was in both `app` and `feature1` and its value in `app` was `value1-overriden` ⇒ it gets moved into `feature1`, retaining the value it had in `app`.
+
+But `key3` was only in `app` so it stays in `app`.
 
 # Supported sources
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,14 @@ The plugin provides the following gradle tasks:
       \_key2: value2
     ```
     
-    Calling `androidI18nDeduplicate -PandroidI18n.deduplicateFrom=app` will make it:
+    Here is how you call the task:
+
+    ```bash
+    ./gradlew androidI18nDeduplicate -PandroidI18n.deduplicateFrom=app
+    ```
+
+    The task transforms the project to:
+
     ```
     project
     \_app

--- a/README.md
+++ b/README.md
@@ -23,6 +23,32 @@ The plugin provides the following gradle tasks:
     [...]
     ```
 
+- **`androidI18nDeduplicate`**: remove duplicate keys between a given source module and the other modules in the Gradle project. NB: This task operates on the `*strings.xml` files of the project.
+
+    For example if the project has 2 modules:
+    ```
+    project
+    \_app
+    | \_key1: value1-overriden
+    | \_key3: value3
+    \_feature1
+      \_key1: value1-feature1
+      \_key2: value2
+    ```
+    
+    Calling `androidI18nDeduplicate -PandroidI18n.deduplicateFrom=app` will make it:
+    ```
+    project
+    \_app
+    | \_key3: value3
+    \_feature1
+      \_key1: value1-overriden
+      \_key2: value2
+    ```
+
+    The key `key1` was in both `app` and `feature1` and its value in `app` was `value1-overriden` ⇒ it gets moved into `feature1`, retaining the value it had in `app`.
+
+    But `key3` was only in `app` so it stays in `app`.
 
 # Installation
 

--- a/src/main/kotlin/com/github/gradle/android/i18n/AndroidI18nPlugin.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/AndroidI18nPlugin.kt
@@ -37,5 +37,14 @@ class AndroidI18nPlugin : Plugin<Project> {
                 }
             }
         }
+
+        project.tasks.let { task ->
+            task.create("androidI18nDispatch").apply {
+                doLast {
+                    println("Dispatching android i18n keys from main module")
+                    extension.dispatchKeys()
+                }
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/github/gradle/android/i18n/AndroidI18nPlugin.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/AndroidI18nPlugin.kt
@@ -39,10 +39,10 @@ class AndroidI18nPlugin : Plugin<Project> {
         }
 
         project.tasks.let { task ->
-            task.create("androidI18nDispatch").apply {
+            task.create("androidI18nDeduplicate").apply {
                 doLast {
-                    println("Dispatching android i18n keys from main module")
-                    extension.dispatchKeys()
+                    println("Deduplicate android i18n keys from main module")
+                    extension.deduplicateKeys()
                 }
             }
         }

--- a/src/main/kotlin/com/github/gradle/android/i18n/AndroidI18nPluginExtension.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/AndroidI18nPluginExtension.kt
@@ -1,12 +1,8 @@
 package com.github.gradle.android.i18n
 
 import com.github.gradle.android.i18n.export.XlsExporter
-import com.github.gradle.android.i18n.export.deserializeResources
-import com.github.gradle.android.i18n.export.toProjectData
 import com.github.gradle.android.i18n.import.ImportConfig
 import com.github.gradle.android.i18n.import.XlsImporter
-import com.github.gradle.android.i18n.import.toStringResourcesByPath
-import com.github.gradle.android.i18n.import.write
 import jcifs.smb.SmbFile
 import org.gradle.api.Project
 import java.io.File

--- a/src/main/kotlin/com/github/gradle/android/i18n/AndroidI18nPluginExtension.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/AndroidI18nPluginExtension.kt
@@ -55,7 +55,7 @@ open class AndroidI18nPluginExtension(
      */
     var importSheetNameRegex: String = "^.*$"
 
-    var dispatchFrom: String? = null
+    var deduplicateFrom: String? = null
 
     /**
      * Imports the i18n translation resources from the configured [sourceFile].
@@ -148,15 +148,19 @@ open class AndroidI18nPluginExtension(
             }
     }
 
-    fun dispatchKeys() {
-        val dispatchFromProp = dispatchFrom ?: project.findProperty("androidI18n.dispatchFrom")
-        val dispatchFrom = dispatchFromProp as? String
-        if (dispatchFrom != null) {
-            println("Dispatching keys from $dispatchFrom...")
+    fun deduplicateKeys() {
+        val deduplicateFromProp = deduplicateFrom ?: project.findProperty("androidI18n.deduplicateFrom")
+        val deduplicateFrom = deduplicateFromProp as? String
+        if (deduplicateFrom != null) {
+            println("Deduplicating keys from $deduplicateFrom...")
             val projData = project.deserializeResources(defaultLocale).toProjectData()
-            val projDataWithKeysDispatched = projData.deduplicated(dispatchFromProp)
-            projDataWithKeysDispatched.toStringResourcesByPath(project.projectDir, defaultLocale).write()
-            println("Resources have been written to $project.projectDir")
+            val deduplicatedProjData = projData.deduplicated(deduplicateFromProp)
+            deduplicatedProjData
+                .toStringResourcesByPath(project.projectDir, defaultLocale)
+                .write()
+            println("Resources have been written to ${project.projectDir}")
+        } else {
+            println("Please supply a value for property `androidI18n.deduplicateFrom`")
         }
     }
 

--- a/src/main/kotlin/com/github/gradle/android/i18n/AndroidI18nPluginExtension.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/AndroidI18nPluginExtension.kt
@@ -1,8 +1,12 @@
 package com.github.gradle.android.i18n
 
 import com.github.gradle.android.i18n.export.XlsExporter
+import com.github.gradle.android.i18n.export.deserializeResources
+import com.github.gradle.android.i18n.export.toProjectData
 import com.github.gradle.android.i18n.import.ImportConfig
 import com.github.gradle.android.i18n.import.XlsImporter
+import com.github.gradle.android.i18n.import.toStringResourcesByPath
+import com.github.gradle.android.i18n.import.write
 import jcifs.smb.SmbFile
 import org.gradle.api.Project
 import java.io.File
@@ -50,6 +54,8 @@ open class AndroidI18nPluginExtension(
      * Default is `.*` to read all sheets.
      */
     var importSheetNameRegex: String = "^.*$"
+
+    var dispatchFrom: String? = null
 
     /**
      * Imports the i18n translation resources from the configured [sourceFile].
@@ -140,6 +146,18 @@ open class AndroidI18nPluginExtension(
             .forEach {
                 jcifs.Config.setProperty(it.key.substringAfter('.'), it.value.toString().trim())
             }
+    }
+
+    fun dispatchKeys() {
+        val dispatchFromProp = dispatchFrom ?: project.findProperty("androidI18n.dispatchFrom")
+        val dispatchFrom = dispatchFromProp as? String
+        if (dispatchFrom != null) {
+            println("Dispatching keys from $dispatchFrom...")
+            val projData = project.deserializeResources(defaultLocale).toProjectData()
+            val projDataWithKeysDispatched = projData.withKeysDispatched(dispatchFromProp)
+            projDataWithKeysDispatched.toStringResourcesByPath(project.projectDir, defaultLocale).write()
+            println("Resources have been written to $project.projectDir")
+        }
     }
 
     companion object {

--- a/src/main/kotlin/com/github/gradle/android/i18n/AndroidI18nPluginExtension.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/AndroidI18nPluginExtension.kt
@@ -154,7 +154,7 @@ open class AndroidI18nPluginExtension(
         if (dispatchFrom != null) {
             println("Dispatching keys from $dispatchFrom...")
             val projData = project.deserializeResources(defaultLocale).toProjectData()
-            val projDataWithKeysDispatched = projData.withKeysDispatched(dispatchFromProp)
+            val projDataWithKeysDispatched = projData.deduplicated(dispatchFromProp)
             projDataWithKeysDispatched.toStringResourcesByPath(project.projectDir, defaultLocale).write()
             println("Resources have been written to $project.projectDir")
         }

--- a/src/main/kotlin/com/github/gradle/android/i18n/Resources.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/Resources.kt
@@ -1,0 +1,212 @@
+package com.github.gradle.android.i18n
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.github.gradle.android.i18n.conf.Configuration
+import com.github.gradle.android.i18n.import.QUANTITY_SEPARATOR
+import com.github.gradle.android.i18n.model.*
+import org.gradle.api.Project
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+
+fun Map<Path, StringResources>.write() {
+    forEach { (path, stringResources) ->
+        val outputResFile = path.toFile()
+        outputResFile.parentFile.mkdirs()
+        Configuration.xmlMapper.writeValue(outputResFile, stringResources)
+    }
+}
+
+fun Project.deserializeResources(defaultLocale: String): Map<Project, List<StringResources>> {
+
+    val result = mutableMapOf<Project, List<StringResources>>()
+
+    forEachModule { moduleProject ->
+        val resources = moduleResources(moduleProject.projectDir.absolutePath, defaultLocale)
+        if (resources.isNotEmpty()) {
+            result[moduleProject] = resources
+        }
+    }
+
+    return result
+}
+
+/**
+ * Apply a callback to each module project that is a child of the receiver.
+ *
+ * Given a project `rootProject` with the following structure:
+ *
+ * ```
+ * :app
+ * :features:feature1
+ * :features:feature2
+ * :library:library1
+ * :library:library2
+ * ```
+ *
+ * Calling `rootProject.forEachModule(callback) will apply the callback
+ * to `app`, `feature1`, `feature2`, `library1` and `library2`
+ * but not to `features` and `library` that are also considered by Gradle as child projects.
+ */
+private fun Project.forEachModule(callback: (Project) -> Unit) {
+    if (this.childProjects.isEmpty()) {
+        callback(this)
+    } else {
+        this.childProjects.forEach { (_, childProj) ->
+            childProj.forEachModule(callback)
+        }
+    }
+}
+
+private fun moduleResources(
+    modulePath: String,
+    defaultLocale: String
+): List<StringResources> {
+
+    val resFolderPattern = "values(-(.*))?".toRegex()
+
+    val resources = mutableListOf<StringResources>()
+    Paths.get(modulePath, "src", "main", "res")
+        .toFile()
+        .walkTopDown()
+        .maxDepth(1)
+        .filter { it.isDirectory && resFolderPattern.matches(it.name) }
+        .sortedBy { it.path }
+        .map { resourcesInDirectory(it, resFolderPattern, defaultLocale) }
+        .filter { it.strings.isNotEmpty() || it.plurals.isNotEmpty() }
+        .forEach { resources.add(it) }
+    return resources
+}
+
+private fun resourcesInDirectory(
+
+    directory: File,
+    resFolderPattern: Regex,
+    defaultLocale: String
+
+): StringResources {
+
+    val locale = resFolderPattern.matchEntire(directory.name)!!.groupValues[2]
+
+    return directory.walkTopDown()
+        .maxDepth(1)
+        .firstOrNull { file -> file.name.endsWith("strings.xml") }
+        ?.let { stringsFile -> Configuration.xmlMapper.readValue<StringResources>(stringsFile.inputStream()) }
+        ?.let { stringResources ->
+            if (locale.isBlank()) {
+                stringResources.copy(locale = defaultLocale, defaultLocale = true)
+            } else {
+                stringResources.copy(locale = locale, defaultLocale = false)
+            }
+        } ?: StringResources()
+}
+
+fun Map<Project, List<StringResources>>.toProjectData(): ProjectData {
+
+    val modules = map { (moduleProj, resources) ->
+        val moduleDataName = moduleProj.path
+            .replace("^:".toRegex(), "")
+            .replaceFirst(':', '.')
+            .replace(':', '-')
+            .let { name ->
+                if (name.isNotEmpty()) name
+                else ModuleData.DEFAULT_NAME
+            }
+        val translations = resources.map { it.toTranslationData() }
+        ModuleData(moduleDataName, translations)
+    }
+    return ProjectData(modules)
+}
+
+private fun StringResources.toTranslationData(): TranslationData {
+    val fromStrings = strings.map { it.toStringData() }.sortedBy { it.name }
+    val fromPlurals = plurals.flatMap { it.toStringDataList() }
+    val stringDataList = fromStrings + fromPlurals
+    return TranslationData(locale, stringDataList)
+}
+
+private fun XmlResource.toStringData(): StringData = StringData(name, text?.unescapeQuotes)
+private fun XmlResources.toStringDataList(): List<StringData> = items.map {
+    val namePrefix =
+        if (name.isBlank()) ""
+        else "${name}:"
+    StringData(namePrefix + it.quantity, it.text?.unescapeQuotes)
+}
+
+internal val String.unescapeQuotes: String get() = this.replace("\\'", "'")
+fun ProjectData.toStringResourcesByPath(
+    baseDir: File,
+    defaultLocale: String
+): Map<Path, StringResources> {
+    val isMultiModule = this.modules.size > 1
+    return this.modules.map { moduleData ->
+        val moduleBaseDir = if (isMultiModule) File(baseDir, moduleData.pathRelativeToProj()).path else baseDir.path
+        val moduleResPath = Paths.get(moduleBaseDir, "src", "main", "res")
+        Pair(moduleResPath, moduleData)
+    }.flatMap { (resDirPath, moduleData) ->
+        moduleData.translations.map { translationData ->
+            val valuesPath =
+                if (translationData.locale == defaultLocale) "values"
+                else "values-${translationData.locale}"
+            val stringsFileName = if (isMultiModule) moduleData.stringsFileName() else "strings.xml"
+            val stringsFileSubPath = Paths.get(valuesPath, stringsFileName)
+            val stringsFileFullPath = resDirPath.resolve(stringsFileSubPath)
+            val stringResources = translationData.toStringResources(defaultLocale)
+            Pair(stringsFileFullPath, stringResources)
+        }
+    }.associateBy({ it.first }) { it.second }
+}
+
+private fun ModuleData.stringsFileName(): String =
+    "${this.name
+        .replace("^[^.]*\\.".toRegex(), "")
+        .replace('-', '_')}_strings.xml"
+
+private fun ModuleData.pathRelativeToProj(): String =
+    this.name.split(".").joinToString(File.separator)
+
+private fun TranslationData.toStringResources(defaultLocale: String): StringResources {
+
+    val stringDataListByPlurality = this.stringDataList.groupBy {
+        it.name?.contains(QUANTITY_SEPARATOR) == true
+    }
+
+    val singularStringDataList = stringDataListByPlurality[false]
+    val pluralStringDataList = stringDataListByPlurality[true]
+
+    return StringResources(
+        locale,
+        locale == defaultLocale,
+        singularStringDataList
+            ?.sortedBy { (name, _) -> name }
+            ?.toSingularXmlResourceList()
+            ?.toMutableList()
+            ?: mutableListOf(),
+        pluralStringDataList
+            ?.sortedBy { (name, _) -> name }
+            ?.toPluralXmlResourcesList()
+            ?.toMutableList()
+            ?: mutableListOf()
+    )
+}
+
+private fun List<StringData>.toPluralXmlResourcesList(): List<XmlResources> {
+    val groupedByPluralKey = groupBy { stringData: StringData ->
+        assert(stringData.name?.contains(QUANTITY_SEPARATOR) == true)
+        stringData.name?.split(QUANTITY_SEPARATOR)!!.first()
+    }
+    return groupedByPluralKey.map { (pluralName, pluralStringDataList) ->
+        XmlResources(
+            pluralName,
+            pluralStringDataList.map { stringData ->
+                val quantity = stringData.name?.split(QUANTITY_SEPARATOR)?.get(1)
+                XmlResource(name = null, quantity = quantity, text = stringData.text)
+            }.toMutableList()
+        )
+    }
+}
+
+private fun List<StringData>.toSingularXmlResourceList(): List<XmlResource> =
+    map { stringData ->
+        XmlResource(name = stringData.name, text = stringData.text)
+    }.sortedBy { it.name }

--- a/src/main/kotlin/com/github/gradle/android/i18n/export/AbstractExporter.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/export/AbstractExporter.kt
@@ -26,7 +26,7 @@ abstract class AbstractExporter(private val project: Project) {
         project.deserializeResources(defaultLocale).toProjectData()
 }
 
-private fun Project.deserializeResources(defaultLocale: String): Map<Project, List<StringResources>> {
+fun Project.deserializeResources(defaultLocale: String): Map<Project, List<StringResources>> {
 
     val result = mutableMapOf<Project, List<StringResources>>()
 
@@ -67,7 +67,7 @@ private fun Project.forEachModule(callback: (Project) -> Unit) {
     }
 }
 
-private fun Map<Project, List<StringResources>>.toProjectData(): ProjectData {
+fun Map<Project, List<StringResources>>.toProjectData(): ProjectData {
 
     val modules = map { (moduleProj, resources) ->
         val moduleDataName = moduleProj.path

--- a/src/main/kotlin/com/github/gradle/android/i18n/export/AbstractExporter.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/export/AbstractExporter.kt
@@ -1,12 +1,10 @@
 package com.github.gradle.android.i18n.export
 
-import com.fasterxml.jackson.module.kotlin.readValue
-import com.github.gradle.android.i18n.conf.Configuration.xmlMapper
+import com.github.gradle.android.i18n.deserializeResources
 import com.github.gradle.android.i18n.model.*
+import com.github.gradle.android.i18n.toProjectData
 import org.gradle.api.Project
-import java.io.File
 import java.io.OutputStream
-import java.nio.file.Paths
 
 /**
  * Android `xml` string resources exporter.
@@ -26,121 +24,3 @@ abstract class AbstractExporter(private val project: Project) {
         project.deserializeResources(defaultLocale).toProjectData()
 }
 
-fun Project.deserializeResources(defaultLocale: String): Map<Project, List<StringResources>> {
-
-    val result = mutableMapOf<Project, List<StringResources>>()
-
-    forEachModule { moduleProject ->
-        val resources = moduleResources(moduleProject.projectDir.absolutePath, defaultLocale)
-        if (resources.isNotEmpty()) {
-            result[moduleProject] = resources
-        }
-    }
-
-    return result
-}
-
-/**
- * Apply a callback to each module project that is a child of the receiver.
- *
- * Given a project `rootProject` with the following structure:
- *
- * ```
- * :app
- * :features:feature1
- * :features:feature2
- * :library:library1
- * :library:library2
- * ```
- *
- * Calling `rootProject.forEachModule(callback) will apply the callback
- * to `app`, `feature1`, `feature2`, `library1` and `library2`
- * but not to `features` and `library` that are also considered by Gradle as child projects.
- */
-private fun Project.forEachModule(callback: (Project) -> Unit) {
-    if (this.childProjects.isEmpty()) {
-        callback(this)
-    } else {
-        this.childProjects.forEach { (_, childProj) ->
-            childProj.forEachModule(callback)
-        }
-    }
-}
-
-fun Map<Project, List<StringResources>>.toProjectData(): ProjectData {
-
-    val modules = map { (moduleProj, resources) ->
-        val moduleDataName = moduleProj.path
-            .replace("^:".toRegex(), "")
-            .replaceFirst(':', '.')
-            .replace(':', '-')
-            .let { name ->
-                if (name.isNotEmpty()) name
-                else ModuleData.DEFAULT_NAME
-            }
-        val translations = resources.map { it.toTranslationData() }
-        ModuleData(moduleDataName, translations)
-    }
-    return ProjectData(modules)
-}
-
-private fun StringResources.toTranslationData(): TranslationData {
-    val fromStrings = strings.map { it.toStringData() }.sortedBy { it.name }
-    val fromPlurals = plurals.flatMap { it.toStringDataList() }
-    val stringDataList = fromStrings + fromPlurals
-    return TranslationData(locale, stringDataList)
-}
-
-private fun XmlResource.toStringData(): StringData = StringData(name, text?.unescapeQuotes)
-
-private fun XmlResources.toStringDataList(): List<StringData> = items.map {
-    val namePrefix =
-        if (name.isBlank()) ""
-        else "${name}:"
-    StringData(namePrefix + it.quantity, it.text?.unescapeQuotes)
-}
-
-private fun moduleResources(
-    modulePath: String,
-    defaultLocale: String
-): List<StringResources> {
-
-    val resFolderPattern = "values(-(.*))?".toRegex()
-
-    val resources = mutableListOf<StringResources>()
-    Paths.get(modulePath, "src", "main", "res")
-        .toFile()
-        .walkTopDown()
-        .maxDepth(1)
-        .filter { it.isDirectory && resFolderPattern.matches(it.name) }
-        .sortedBy { it.path }
-        .map { resourcesInDirectory(it, resFolderPattern, defaultLocale) }
-        .filter { it.strings.isNotEmpty() || it.plurals.isNotEmpty() }
-        .forEach { resources.add(it) }
-    return resources
-}
-
-private fun resourcesInDirectory(
-
-    directory: File,
-    resFolderPattern: Regex,
-    defaultLocale: String
-
-): StringResources {
-
-    val locale = resFolderPattern.matchEntire(directory.name)!!.groupValues[2]
-
-    return directory.walkTopDown()
-        .maxDepth(1)
-        .firstOrNull { file -> file.name.endsWith("strings.xml") }
-        ?.let { stringsFile -> xmlMapper.readValue<StringResources>(stringsFile.inputStream()) }
-        ?.let { stringResources ->
-            if (locale.isBlank()) {
-                stringResources.copy(locale = defaultLocale, defaultLocale = true)
-            } else {
-                stringResources.copy(locale = locale, defaultLocale = false)
-            }
-        } ?: StringResources()
-}
-
-internal val String.unescapeQuotes: String get() = this.replace("\\'", "'")

--- a/src/main/kotlin/com/github/gradle/android/i18n/import/XlsImporter.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/import/XlsImporter.kt
@@ -1,16 +1,14 @@
 package com.github.gradle.android.i18n.import
 
-import com.github.gradle.android.i18n.conf.Configuration
 import com.github.gradle.android.i18n.model.*
+import com.github.gradle.android.i18n.toStringResourcesByPath
+import com.github.gradle.android.i18n.write
 import org.apache.poi.ss.usermodel.Row
 import org.apache.poi.ss.usermodel.Sheet
 import org.apache.poi.ss.usermodel.Workbook
 import org.apache.poi.ss.usermodel.WorkbookFactory
 import org.gradle.api.Project
-import java.io.File
 import java.io.InputStream
-import java.nio.file.Path
-import java.nio.file.Paths
 
 /**
  * Android i18n resources importer from `.xls` and `.xlsx` sources.
@@ -140,89 +138,4 @@ private fun readWorkbookRows(config: ImportConfig, workbook: Workbook): List<Row
         }
     }
     return result
-}
-
-fun ProjectData.toStringResourcesByPath(
-    baseDir: File,
-    defaultLocale: String
-): Map<Path, StringResources> {
-    val isMultiModule = this.modules.size > 1
-    return this.modules.map { moduleData ->
-        val moduleBaseDir = if (isMultiModule) File(baseDir, moduleData.pathRelativeToProj()).path else baseDir.path
-        val moduleResPath = Paths.get(moduleBaseDir, "src", "main", "res")
-        Pair(moduleResPath, moduleData)
-    }.flatMap { (resDirPath, moduleData) ->
-        moduleData.translations.map { translationData ->
-            val valuesPath =
-                if (translationData.locale == defaultLocale) "values"
-                else "values-${translationData.locale}"
-            val stringsFileName = if (isMultiModule) moduleData.stringsFileName() else "strings.xml"
-            val stringsFileSubPath = Paths.get(valuesPath, stringsFileName)
-            val stringsFileFullPath = resDirPath.resolve(stringsFileSubPath)
-            val stringResources = translationData.toStringResources(defaultLocale)
-            Pair(stringsFileFullPath, stringResources)
-        }
-    }.associateBy({ it.first }) { it.second }
-}
-
-private fun ModuleData.stringsFileName(): String =
-    "${this.name
-        .replace("^[^.]*\\.".toRegex(), "")
-        .replace('-', '_')}_strings.xml"
-
-private fun ModuleData.pathRelativeToProj(): String =
-    this.name.split(".").joinToString(File.separator)
-
-private fun TranslationData.toStringResources(defaultLocale: String): StringResources {
-
-    val stringDataListByPlurality = this.stringDataList.groupBy {
-        it.name?.contains(QUANTITY_SEPARATOR) == true
-    }
-
-    val singularStringDataList = stringDataListByPlurality[false]
-    val pluralStringDataList = stringDataListByPlurality[true]
-
-    return StringResources(
-        locale,
-        locale == defaultLocale,
-        singularStringDataList
-            ?.sortedBy { (name, _) -> name }
-            ?.toSingularXmlResourceList()
-            ?.toMutableList()
-            ?: mutableListOf(),
-        pluralStringDataList
-            ?.sortedBy { (name, _) -> name }
-            ?.toPluralXmlResourcesList()
-            ?.toMutableList()
-            ?: mutableListOf()
-    )
-}
-
-private fun List<StringData>.toPluralXmlResourcesList(): List<XmlResources> {
-    val groupedByPluralKey = groupBy { stringData: StringData ->
-        assert(stringData.name?.contains(QUANTITY_SEPARATOR) == true)
-        stringData.name?.split(QUANTITY_SEPARATOR)!!.first()
-    }
-    return groupedByPluralKey.map { (pluralName, pluralStringDataList) ->
-        XmlResources(
-            pluralName,
-            pluralStringDataList.map { stringData ->
-                val quantity = stringData.name?.split(QUANTITY_SEPARATOR)?.get(1)
-                XmlResource(name = null, quantity = quantity, text = stringData.text)
-            }.toMutableList()
-        )
-    }
-}
-
-private fun List<StringData>.toSingularXmlResourceList(): List<XmlResource> =
-    map { stringData ->
-        XmlResource(name = stringData.name, text = stringData.text)
-    }.sortedBy { it.name }
-
-fun Map<Path, StringResources>.write() {
-    forEach { (path, stringResources) ->
-        val outputResFile = path.toFile()
-        outputResFile.parentFile.mkdirs()
-        Configuration.xmlMapper.writeValue(outputResFile, stringResources)
-    }
 }

--- a/src/main/kotlin/com/github/gradle/android/i18n/model/ProjectData.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/model/ProjectData.kt
@@ -4,4 +4,9 @@ package com.github.gradle.android.i18n.model
  * This class represents a Gradle project in the context of i18n import/export.
  * @param modules a representation of the submodules of the project
  */
-data class ProjectData(val modules: List<ModuleData>)
+data class ProjectData(val modules: List<ModuleData>) {
+
+    fun withKeysDispatched(sourceModuleName: String): ProjectData {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/com/github/gradle/android/i18n/model/ProjectData.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/model/ProjectData.kt
@@ -16,7 +16,7 @@ data class ProjectData(val modules: List<ModuleData>) {
      * ```
      * projectData
      * \_app
-     * | \_key1: value1-overriden
+     * | \_key1: value1-app
      * | \_key3: value3
      * \_feature1
      *   \_key1: value1-feature1
@@ -30,7 +30,7 @@ data class ProjectData(val modules: List<ModuleData>) {
      * \_app
      * | \_key3: value3
      * \_feature1
-     *   \_key1: value1-overriden
+     *   \_key1: value1-app
      *   \_key2: value2
      * ```
      */

--- a/src/main/kotlin/com/github/gradle/android/i18n/model/ProjectData.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/model/ProjectData.kt
@@ -38,6 +38,18 @@ data class ProjectData(val modules: List<ModuleData>) {
             .partition { it.name == sourceModuleName }
             .let { (sourceModules, otherModules) -> sourceModules.first() to otherModules }
 
+        val sourceModuleDeduplicated =
+            sourceModule.copy(translations = sourceModule.translations.map { sourceTranslationData ->
+                sourceTranslationData.copy(stringDataList = sourceTranslationData.stringDataList.filter { sourceString ->
+                    otherModules.none { otherModule ->
+                        otherModule.translations
+                            .find { it.locale == sourceTranslationData.locale }
+                            ?.stringDataList
+                            ?.any { it.name == sourceString.name } == true
+                    }
+                })
+            })
+
         val otherModulesOverriden = otherModules.map { otherModule ->
             otherModule.copy(translations = otherModule.translations.map { otherTranslation ->
                 otherTranslation.copy(stringDataList = otherTranslation.stringDataList.map { string ->
@@ -52,6 +64,7 @@ data class ProjectData(val modules: List<ModuleData>) {
                 })
             })
         }
-        return ProjectData(listOf(sourceModule) + otherModulesOverriden)
+
+        return ProjectData(listOf(sourceModuleDeduplicated) + otherModulesOverriden)
     }
 }

--- a/src/main/kotlin/com/github/gradle/android/i18n/model/ProjectData.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/model/ProjectData.kt
@@ -6,7 +6,33 @@ package com.github.gradle.android.i18n.model
  */
 data class ProjectData(val modules: List<ModuleData>) {
 
-    fun withKeysDispatched(sourceModuleName: String): ProjectData {
+    /**
+     * Copy this [ProjectData], removing duplicate keys between a given source module (aka main module) and the other modules in the project.
+     *
+     * For example if `projectData` represents a project with 2 modules:
+     *
+     * ```
+     * projectData
+     * \_app
+     * | \_key1: value1-overriden
+     * | \_key3: value3
+     * \_feature1
+     *   \_key1: value1-feature1
+     *   \_key2: value2
+     * ```
+     *
+     * Calling `projectData.deduplicated("app")` will return:
+     *
+     * ```
+     * projectData
+     * \_app
+     * | \_key3: value3
+     * \_feature1
+     *   \_key1: value1-overriden
+     *   \_key2: value2
+     * ```
+     */
+    fun deduplicated(sourceModuleName: String): ProjectData {
         TODO("Not yet implemented")
     }
 }

--- a/src/main/kotlin/com/github/gradle/android/i18n/model/ProjectData.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/model/ProjectData.kt
@@ -33,6 +33,25 @@ data class ProjectData(val modules: List<ModuleData>) {
      * ```
      */
     fun deduplicated(sourceModuleName: String): ProjectData {
-        TODO("Not yet implemented")
+
+        val (sourceModule, otherModules) = modules
+            .partition { it.name == sourceModuleName }
+            .let { (sourceModules, otherModules) -> sourceModules.first() to otherModules }
+
+        val otherModulesOverriden = otherModules.map { otherModule ->
+            otherModule.copy(translations = otherModule.translations.map { otherTranslation ->
+                otherTranslation.copy(stringDataList = otherTranslation.stringDataList.map { string ->
+                    string.copy(
+                        text = sourceModule.translations
+                            .find { it.locale == otherTranslation.locale }
+                            ?.stringDataList
+                            ?.find { it.name == string.name }
+                            ?.text
+                            ?: string.text
+                    )
+                })
+            })
+        }
+        return ProjectData(listOf(sourceModule) + otherModulesOverriden)
     }
 }

--- a/src/main/kotlin/com/github/gradle/android/i18n/model/TranslationData.kt
+++ b/src/main/kotlin/com/github/gradle/android/i18n/model/TranslationData.kt
@@ -6,4 +6,4 @@ package com.github.gradle.android.i18n.model
  * @param stringDataList a list of translated labels. All of these are in the considered language:
  * if [locale] is `fr`, all [StringData]s are in french.
  */
-class TranslationData(val locale: String, val stringDataList: List<StringData>)
+data class TranslationData(val locale: String, val stringDataList: List<StringData>)

--- a/src/test/kotlin/com/github/gradle/android/i18n/model/ProjectDataTest.kt
+++ b/src/test/kotlin/com/github/gradle/android/i18n/model/ProjectDataTest.kt
@@ -1,0 +1,102 @@
+package com.github.gradle.android.i18n.model
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class ProjectDataTest {
+
+    @Test
+    fun `should deduplicate by overriding values in other modules`() {
+
+        val givenProjectData = ProjectData(
+            listOf(
+                ModuleData(
+                    "app",
+                    listOf(
+                        TranslationData(
+                            "fr",
+                            listOf(
+                                StringData("key1", "valeur1-surchargée"),
+                                StringData("key3", "valeur3")
+                            )
+                        ),
+                        TranslationData(
+                            "en",
+                            listOf(
+                                StringData("key1", "value1-overriden"),
+                                StringData("key3", "value3")
+                            )
+                        )
+                    )
+                ),
+                ModuleData(
+                    "feature1",
+                    listOf(
+                        TranslationData(
+                            "fr",
+                            listOf(
+                                StringData("key1", "valeur1-base"),
+                                StringData("key2", "valeur2")
+                            )
+                        ),
+                        TranslationData(
+                            "en",
+                            listOf(
+                                StringData("key1", "value1-base"),
+                                StringData("key2", "value2")
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val deduplicated = givenProjectData.deduplicated("app")
+
+        assertEquals(
+            ProjectData(
+                listOf(
+                    ModuleData(
+                        "app",
+                        listOf(
+                            TranslationData(
+                                "fr",
+                                listOf(
+                                    StringData("key1", "valeur1-surchargée"), // TODO: Source key removal
+                                    StringData("key3", "valeur3")
+                                )
+                            ),
+                            TranslationData(
+                                "en",
+                                listOf(
+                                    StringData("key1", "value1-overriden"), // TODO: Source key removal
+                                    StringData("key3", "value3")
+                                )
+                            )
+                        )
+                    ),
+                    ModuleData(
+                        "feature1",
+                        listOf(
+                            TranslationData(
+                                "fr",
+                                listOf(
+                                    StringData("key1", "valeur1-surchargée"),
+                                    StringData("key2", "valeur2")
+                                )
+                            ),
+                            TranslationData(
+                                "en",
+                                listOf(
+                                    StringData("key1", "value1-overriden"),
+                                    StringData("key2", "value2")
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            deduplicated
+        )
+    }
+}

--- a/src/test/kotlin/com/github/gradle/android/i18n/model/ProjectDataTest.kt
+++ b/src/test/kotlin/com/github/gradle/android/i18n/model/ProjectDataTest.kt
@@ -62,14 +62,12 @@ class ProjectDataTest {
                             TranslationData(
                                 "fr",
                                 listOf(
-                                    StringData("key1", "valeur1-surchargée"), // TODO: Source key removal
                                     StringData("key3", "valeur3")
                                 )
                             ),
                             TranslationData(
                                 "en",
                                 listOf(
-                                    StringData("key1", "value1-overriden"), // TODO: Source key removal
                                     StringData("key3", "value3")
                                 )
                             )


### PR DESCRIPTION
This PR brings a new `androidI18nDeduplicate` task to merge duplicates between a source module and other modules.

The changes can be split in 2 parts:

1. Refactor the Importer and Exporter to make some `ProjectData` extensions functions public
2. Use the `ProjectData` mapping functions to implement the task in 3 steps:
    - Deserialize the project's string resources
    - Deduplicate the keys using the `ProjectData.deduplicate` method
    - Serialize back